### PR TITLE
Post Requests to API Sources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ gem "sidekiq"
 gem "letter_opener", group: :development
 
 # send http calls
-gem "http"
+gem "rest-client"
 
 group :development, :test do
   # Rails integration for factory-bot

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,9 +117,6 @@ GEM
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
     ffi (1.15.0)
-    ffi-compiler (1.0.1)
-      ffi (>= 1.0.0)
-      rake
     formtastic (4.0.0)
       actionpack (>= 5.2.0)
     formtastic_i18n (0.6.0)
@@ -129,14 +126,9 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
     honeybadger (4.7.2)
-    http (5.0.1)
-      addressable (~> 2.3)
-      http-cookie (~> 1.0)
-      http-form_data (~> 2.2)
-      llhttp-ffi (~> 0.3.0)
+    http-accept (1.7.0)
     http-cookie (1.0.4)
       domain_name (~> 0.5)
-    http-form_data (2.3.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.13.0)
@@ -169,9 +161,6 @@ GEM
     listen (3.3.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    llhttp-ffi (0.3.1)
-      ffi-compiler (~> 1.0)
-      rake (~> 13.0)
     loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -181,12 +170,16 @@ GEM
       activesupport
     marcel (1.0.1)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0704)
     mini_mime (1.0.3)
     mini_portile2 (2.5.1)
     minitest (5.14.4)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
     msgpack (1.4.2)
+    netrc (0.11.0)
     nio4r (2.5.7)
     nokogiri (1.11.4)
       mini_portile2 (~> 2.5.0)
@@ -254,6 +247,11 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rubocop (1.4.1)
       parallel (~> 1.10)
@@ -354,7 +352,6 @@ DEPENDENCIES
   email_validator
   factory_bot_rails
   honeybadger
-  http
   jbuilder (>= 2.7)
   letter_opener
   listen (~> 3.2)
@@ -366,6 +363,7 @@ DEPENDENCIES
   puma
   rails (~> 6.1.3.2)
   react-rails
+  rest-client
   rubocop
   rubocop-rails
   ruby_audit

--- a/app/controllers/api/v1/query_groups_controller.rb
+++ b/app/controllers/api/v1/query_groups_controller.rb
@@ -46,8 +46,9 @@ class Api::V1::QueryGroupsController < Api::V1::BaseController
         :http_method,
         :page_size,
         :query_string,
+        :document_uuid,
+        :transform_response,
         request_body: {},
-        transform_response: {},
         document_fields: []
       ).to_h
     end

--- a/app/javascript/src/components/Dashboard/QueryGroups/NewForm.jsx
+++ b/app/javascript/src/components/Dashboard/QueryGroups/NewForm.jsx
@@ -25,6 +25,7 @@ const RequestTypeInputField = ({ showQueryStringField }) => {
 const preProcessObject = (resource) => {
   resource.request_body = deserializeObject(resource.request_body);
   resource.transform_response = deserializeObject(resource.transform_response);
+  resource.document_fields = resource.document_fields.split(',');
 
   if(typeof resource.api_source_id === 'object' && resource.api_source_id !== null) {
     resource.api_source_id = resource.api_source_id.value;
@@ -37,20 +38,23 @@ const preProcessObject = (resource) => {
 
 const defaultValues = (currentResource) => {
   let resourceObj = currentResource || {
-    name: "",
+    name: '',
     api_source_id: 0,
     scorer_id: 0,
     http_method: "GET",
     page_size: 10,
     request_body: {},
-    query_string: "",
-    transform_response: {},
+    query_string: '',
+    transform_response: '',
     document_uuid: '',
     document_fields: []
   };
 
   resourceObj.request_body = serializeObject(resourceObj.request_body);
   resourceObj.transform_response = serializeObject(resourceObj.transform_response);
+  if(Array.isArray(resourceObj.document_fields)) {
+    resourceObj.document_fields = resourceObj.document_fields.join(',');
+  }
 
   return resourceObj;
 }
@@ -104,8 +108,8 @@ export default function NewForm({ onClose, refetch, currentResource }) {
         name: yup.string().required("Name is required"),
         http_method: yup.string().required("HTTP Method is required"),
         page_size: yup.number().required("Page Size is required"),
-        document_uuid: yup.string().required("Document UUID is required"),
-        document_fields: yup.array().required("Document fields are required"),
+        document_uuid: yup.string().required("Unique Document Field is required"),
+        document_fields: yup.string().required("Document fields are required"),
       })}
     >
       {({ isSubmitting }) => (
@@ -147,7 +151,8 @@ export default function NewForm({ onClose, refetch, currentResource }) {
           />
 
           <RequestTypeInputField showQueryStringField={showQueryStringField} />
-          <Input label="Document UUID" name="document_uuid" type="String" className="mb-6" />
+          <Input label="Unique Document Field" name="document_uuid" type="String" className="mb-6" />
+          <Input label="Fields to Display" name="document_fields" type="String" className="mb-6" />
           <Textarea label="Transform Response" name="transform_response" rows={8} className="mb-6" />
           <div className="nui-pane__footer nui-pane__footer--absolute">
             <Button

--- a/db/migrate/20210712162312_change_transform_column_to_string.rb
+++ b/db/migrate/20210712162312_change_transform_column_to_string.rb
@@ -1,0 +1,5 @@
+class ChangeTransformColumnToString < ActiveRecord::Migration[6.1]
+  def change
+    change_column :query_groups, :transform_response, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_11_143725) do
+ActiveRecord::Schema.define(version: 2021_07_12_162312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -98,7 +98,7 @@ ActiveRecord::Schema.define(version: 2021_07_11_143725) do
     t.integer "page_size", null: false
     t.json "request_body"
     t.string "query_string"
-    t.json "transform_response"
+    t.string "transform_response"
     t.json "document_fields", null: false
     t.uuid "user_id"
     t.boolean "is_deleted", default: false, null: false


### PR DESCRIPTION
* Ability to send post requests to sources after interpolating the query text in the request body
* Added the Transforming the request response based on the code block in query group
* Migration for the converting code block to a string column rather than json column
* changed the API request gem from "HTTP" to "RestClient"